### PR TITLE
Fix JsonResponse and RedirectResponse wrapping into TestResponse

### DIFF
--- a/docs/content/en/changelog.md
+++ b/docs/content/en/changelog.md
@@ -10,6 +10,14 @@ All notable changes to this project will be documented in this file. For a full 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+
+### [v1.6.3](https://github.com/pestphp/defstudio-plugin-laravel-expectations/compare/v1.6.2...v1.6.3) - 2021-11-21
+
+**Fix**
+
+- responses are authomatically wrapped in TestResponse objects when are instances of JsonReponse and RedirectResponse
+
+
 ### [v1.6.2](https://github.com/pestphp/defstudio-plugin-laravel-expectations/compare/v1.6.1...v1.6.2) - 2021-11-21
 
 **Fix**

--- a/src/Expectations/Response.php
+++ b/src/Expectations/Response.php
@@ -2,11 +2,25 @@
 
 declare(strict_types=1);
 
+namespace DefStudio\PestLaravelExpectations\Expectations;
+
 use Illuminate\Http\Response;
 use Illuminate\Testing\TestResponse;
 use Pest\Expectation;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\ExpectationFailedException;
+
+function getTestableResponse(Expectation $expectation): TestResponse
+{
+    /** @var TestResponse|Response $response */
+    $response = $expectation->value;
+
+    if ($response instanceof TestResponse) {
+        return $response;
+    }
+
+    return TestResponse::fromBaseResponse($response);
+}
 
 expect()->extend(
     'toBeRedirect',


### PR DESCRIPTION
The `Response` to `TestResponse` corrections actually happens only for `Response` objects

this PR will add `JsonResponse` and `RedirectResponse` to the conversion